### PR TITLE
add huggingface reward

### DIFF
--- a/llm_eval/models/__init__.py
+++ b/llm_eval/models/__init__.py
@@ -43,4 +43,6 @@ def load_model(name: str, **kwargs) -> BaseModel:
 from .openai_backend import OpenAIModel
 from .multi import MultiModel
 from .huggingface_backend import HuggingFaceModel
+from .huggingface_judge import HuggingFaceJudge
+from .huggingface_reward import HuggingFaceReward
 # from litellm_backend import *

--- a/llm_eval/models/huggingface_reward.py
+++ b/llm_eval/models/huggingface_reward.py
@@ -1,0 +1,129 @@
+from typing import List, Dict, Any, Optional, Union
+import logging
+import torch
+import torch.nn.functional as F
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from llm_eval.models.base import BaseRewardModel
+from . import register_model
+from llm_eval.utils.logging import get_logger
+
+logger = get_logger(name="huggingface_reward", level=logging.INFO)
+
+@register_model("huggingface_reward")
+class HuggingFaceReward(BaseRewardModel):
+    """
+    HuggingFaceReward computes a reward for a given sample by calculating the
+    conditional log likelihood (average log probability) of the generated answer.
+
+    For example, for a sample like:
+      {
+         "input": "Problem: ...\nAnswer:",
+         "prediction": " generated answer text..."
+      }
+
+    The reward is computed as the average log probability of the tokens in the generated
+    answer (i.e., the part after the prompt), as predicted by the model.
+    """
+    
+    def __init__(self, model_name_or_path: str, device: str = "cpu", **kwargs):
+        """
+        Args:
+            model_name_or_path (str): HuggingFace model identifier or local path (e.g., "gpt2", "EleutherAI/gpt-neox-20b", etc.)
+            device (str): The device to run the model on ("cpu", "cuda", etc.)
+            **kwargs: Additional arguments as needed.
+        """
+        super().__init__(**kwargs)
+        self.device = device
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+        self.model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
+        self.model.eval()
+        if device != "cpu":
+            self.model.to(device)
+    
+    def score_batch(self, inputs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        For each sample, combine the "input" and "prediction" fields to form the full text,
+        and compute the conditional log likelihood for the tokens corresponding to the generated answer.
+        The reward is computed as the average log probability over these tokens.
+
+        The computation steps are as follows:
+          1. For each sample, construct the full text as input + prediction.
+          2. Calculate the number of tokens in the prompt (input) separately.
+          3. Tokenize the full text in a batch.
+          4. Pass the tokenized inputs through the model to obtain logits.
+          5. Using the shifted logits, compute the log probabilities for each token,
+             and then compute the average log probability over the generated part (after the prompt).
+          6. Add the computed reward to each sample in the "reward" field.
+
+        Args:
+            inputs: List of samples, where each sample must contain at least the "input" and "prediction" fields.
+            
+        Returns:
+            The list of input samples with an additional "reward" field added to each sample.
+        """
+        if not inputs:
+            return inputs
+        
+        batch_size = len(inputs)
+        full_texts = []       # Combined texts: input + prediction
+        prompt_lengths = []   # Number of tokens in the prompt for each sample
+        actual_lengths = []   # Actual token count (before padding) for the full text
+        
+        for sample in inputs:
+            prompt = sample.get("input", "")
+            prediction = sample.get("prediction", "")
+            full_text = prompt + prediction
+            full_texts.append(full_text)
+            
+            # Get the token count for the prompt using the tokenizer.
+            prompt_ids = self.tokenizer.encode(prompt, add_special_tokens=False)
+            prompt_lengths.append(len(prompt_ids))
+            
+            # Get the token count for the full text (before padding).
+            full_ids = self.tokenizer.encode(full_text, add_special_tokens=False)
+            actual_lengths.append(len(full_ids))
+        
+        # Batch tokenize the full texts with padding.
+        encoded = self.tokenizer(
+            full_texts,
+            return_tensors="pt",
+            padding=True,
+            truncation=False
+        )
+        input_ids = encoded["input_ids"].to(self.device)
+        attention_mask = encoded["attention_mask"].to(self.device)
+        
+        with torch.no_grad():
+            outputs = self.model(input_ids)
+            logits = outputs.logits  # shape: (batch_size, seq_len, vocab_size)
+        
+        # Compute the log probabilities for the tokens after the prompt for each sample.
+        rewards = []
+        for i in range(batch_size):
+            p_len = prompt_lengths[i]
+            seq_len = actual_lengths[i]  # Actual sequence length (without padding)
+            
+            # If the full text length is not greater than the prompt length or the prompt is empty, set reward to 0.
+            if seq_len <= p_len or p_len == 0:
+                rewards.append(0.0)
+                continue
+            
+            # For language models, the probability of token j is derived from logits at position j-1.
+            # That is, for tokens full_text[p_len:], the corresponding logits are from logits[i, p_len-1: seq_len-1].
+            logits_i = logits[i, p_len - 1: seq_len - 1, :]  # shape: (seq_len - p_len, vocab_size)
+            target_ids = input_ids[i, p_len:seq_len]           # True token ids for the generated part
+            
+            # Compute log probabilities by applying log_softmax to the logits.
+            log_probs = F.log_softmax(logits_i, dim=-1)         # shape: (seq_len - p_len, vocab_size)
+            # Gather the log probability corresponding to the target token at each position.
+            token_log_probs = log_probs.gather(1, target_ids.unsqueeze(1)).squeeze(1)
+            # Compute the average log probability.
+            avg_log_prob = token_log_probs.mean().item()
+            rewards.append(avg_log_prob)
+        
+        # Add the computed reward to each sample.
+        for i, sample in enumerate(inputs):
+            sample["reward"] = rewards[i]
+        
+        return inputs


### PR DESCRIPTION
add huggingface reward

best_of_n, dvts, beam search 등을 구현하기 위한 reward 모델

프롬프트와 생성된 답변을 결합한 전체 텍스트에서 프롬프트 이후 각 토큰에 대한 로그 확률을 평균내서 보상 값으로 활용 (단순한 방식)

RLHF나 DVTS같은 경우에는, 특정 토큰을 기준으로 모델의 출력에서 각 단계 확률 값을 추출하고 단계별 확률값을 집계하는 방식을 사용함. (RLHFlow, 등)

우리는 단순히 reward model을 score로 활용하는 것이지, 실제 RLHF를 하는 것은 아니어서 이렇게 구현하긴 했지만 더 고도화된 reward가 필요할 경우 본 코드를 고도화 해야할 수도 있음

@guijinSON (내 생각이 잘못되었는지) @ksyint (scaling method 구현 시) 참고 바랍니다