### PR TITLE
do_sample add

### DIFF
--- a/llm_eval/models/huggingface_backend.py
+++ b/llm_eval/models/huggingface_backend.py
@@ -53,6 +53,7 @@ class HuggingFaceModel(BaseModel):
     max_input_tokens: Optional[int] = None,
     temperature: float = 0.0,
     top_p: float = 1.0,
+    do_sample: bool = True,
     stop_token: Optional[str] = None,
     device: Optional[str] = None,
     batch_size: int = 1,
@@ -83,6 +84,7 @@ class HuggingFaceModel(BaseModel):
         self.max_new_tokens = max_new_tokens
         self.temperature = temperature
         self.top_p = top_p
+        self.do_sample = do_sample
         self.cot = cot
         self.cot_trigger = cot_trigger
         self.cot_parser = cot_parser


### PR DESCRIPTION
`hrm8k` 벤치마크에 `do_sample` 관련 인자가 빠져있어 inference시 에러가 발생합니다. 
해당 인자를 추가합니다. 