### PR TITLE
Add configuration-driven evaluator pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Haerae-Evaluation-Toolkit
-[![arXiv](https://img.shields.io/badge/arXiv-2503.22968-b31b1b.svg)](https://arxiv.org/abs/2503.22968) 
+[![arXiv](https://img.shields.io/badge/arXiv-2503.22968-b31b1b.svg)](https://arxiv.org/abs/2503.22968)
 
 <p align="center">
   <img src="assets/imgs/logo.png.png" alt="logo" width="250">
@@ -170,10 +170,44 @@ This command will:
 2. Create a MultiModel internally with:
 Generate model: huggingface → gpt2
 Judge model: huggingface_judge (if you pass relevant judge_params)
-Reward model: huggingface_reward (if you pass relevant reward_params).  
+Reward model: huggingface_reward (if you pass relevant reward_params).
 3. Apply Beam Search (`beam_size=3`).
 4. Evaluate final outputs via `string_match`.
 5. Save the resulting JSON file to `results.json`.
+
+### Configuration File
+
+Instead of passing many arguments, the entire pipeline can be described in a
+single YAML file. Create `evaluator_config.yaml`:
+
+```yaml
+dataset:
+  name: haerae_bench
+  split: test
+  params: {}
+model:
+  name: huggingface
+  params:
+    model_name_or_path: gpt2
+evaluation:
+  method: string_match
+  params: {}
+language_penalize: true
+target_lang: ko
+few_shot:
+  num: 0
+```
+
+Run the configuration with:
+
+```python
+from llm_eval.evaluator import run_from_config
+
+result = run_from_config("evaluator_config.yaml")
+```
+
+See `examples/evaluator_config.yaml` for a full template including judge,
+reward, and scaling options.
 
 
 ---
@@ -227,7 +261,7 @@ with hret.evaluation_context(dataset="kmmlu") as ctx:
     # Add MLOps integrations
     ctx.log_to_mlflow(experiment_name="llm_experiments")
     ctx.log_to_wandb(project_name="model_evaluation")
-    
+
     # Run evaluation
     result = ctx.evaluate(my_model_function)
 ```
@@ -241,7 +275,7 @@ class ModelTrainingPipeline:
         ) as ctx:
             ctx.log_to_mlflow(experiment_name="training")
             result = ctx.evaluate(self.model.generate)
-            
+
             if self.detect_degradation(result):
                 self.send_alert(epoch, result)
 ```
@@ -295,13 +329,13 @@ If you find HRET useful in your research, please consider citing our paper:
 
 ```bibtex
 @misc{lee2025redefiningevaluationstandardsunified,
-      title={Redefining Evaluation Standards: A Unified Framework for Evaluating the Korean Capabilities of Language Models}, 
+      title={Redefining Evaluation Standards: A Unified Framework for Evaluating the Korean Capabilities of Language Models},
       author={Hanwool Lee and Dasol Choi and Sooyong Kim and Ilgyun Jung and Sangwon Baek and Guijin Son and Inseon Hwang and Naeun Lee and Seunghyeok Hong},
       year={2025},
       eprint={2503.22968},
       archivePrefix={arXiv},
       primaryClass={cs.CE},
-      url={https://arxiv.org/abs/2503.22968}, 
+      url={https://arxiv.org/abs/2503.22968},
 }
 ```
 ## 📜 License

--- a/docs/eng/01-quick-start.md
+++ b/docs/eng/01-quick-start.md
@@ -89,7 +89,7 @@ evaluator = Evaluator()
 
 # 2) Run the evaluation pipeline
 results = evaluator.run(
-    model="huggingface",  
+    model="huggingface",
     model_params={
         "model_name_or_path": "kakaocorp/kanana-nano-2.1b-instruct",
         "device": "cuda:0",
@@ -124,6 +124,36 @@ print(results)
 df = results.to_dataframe()
 print(df)  # DataFrame with inputs, references, predictions, logits, etc.
 ```
+
+### Configuration File Usage
+
+You can control the entire pipeline via a single YAML file instead of passing
+parameters in code. Create `evaluator_config.yaml`:
+
+```yaml
+dataset:
+  name: haerae_bench
+  split: test
+  params: {}
+model:
+  name: huggingface
+  params:
+    model_name_or_path: gpt2
+evaluation:
+  method: string_match
+  params: {}
+language_penalize: false
+```
+
+Run the configuration with:
+
+```python
+from llm_eval.evaluator import run_from_config
+
+result = run_from_config("evaluator_config.yaml")
+```
+
+See `examples/evaluator_config.yaml` for a template containing all supported fields.
 
 ### Changing Backend to vLLM or OpenAI-Compatible API
 

--- a/docs/kor/01-quick-start.md
+++ b/docs/kor/01-quick-start.md
@@ -1,27 +1,27 @@
 # 소개 (Introduction)
-HRET(HaeRae Evaluation Toolkit)는 한국어 대형 언어 모델(LLM)에 대해 표준화된 평가환경에서 포괄적인 유효성 검증 기능을 지원하기 위한 오픈소스 라이브러리입니다. 
+HRET(HaeRae Evaluation Toolkit)는 한국어 대형 언어 모델(LLM)에 대해 표준화된 평가환경에서 포괄적인 유효성 검증 기능을 지원하기 위한 오픈소스 라이브러리입니다.
 
 HRET 프레임워크는 기존 한국어 LLM 평가 방식이 일관되지 않아서 직접적인 비교가 어려웠던 것을 보완하기 위해 다음과 같은 목표를 갖고 있습니다.
 
 ## 특징 (Features)
 - HRET는 주요 한국어 벤치마크(HAE-RAE Bench, KMMLU, KUDGE, HRM8K 등)를 통합합니다.
-- 평가 기법(문자열 일치, 언어 불일치 패널티, 로그 확률 기반 평가, LLM-as-judge)을 지원합니다. 
+- 평가 기법(문자열 일치, 언어 불일치 패널티, 로그 확률 기반 평가, LLM-as-judge)을 지원합니다.
   로짓 기반으로 토큰 수준의 확률을 제공하기 때문에 모델 신뢰도 평가까지 가능하며, 한글으로 요청한 사항에 대해 그외 언어가 발생했을 때 검출하여 패널티를 부여할 수 있습니다.
 - Test-time-scale(Beam Search, Best-of-N, Self-Consistency Voting)을 제공하여 언어 모델의 성능을 여러 각도로 평가할 수 있습니다.
-- HuggingFace를 통한 on-premise 사용 뿐만 아니라, litellm, openai-compatible api를 통해 100+개의 online inference와 연동 가능하도록 설계되었습니다. 
+- HuggingFace를 통한 on-premise 사용 뿐만 아니라, litellm, openai-compatible api를 통해 100+개의 online inference와 연동 가능하도록 설계되었습니다.
 - HRET는 한국어 NLP 연구의 재현성과 투명성을 향상시키고, 일관된 대규모 실험 환경을 제공하는 것을 목표로 합니다.
 
 ---
 
 # 설치 (Installation)
-파이썬(python >= 3.10) 가상환경 구축 후 설치를 권장합니다. 
+파이썬(python >= 3.10) 가상환경 구축 후 설치를 권장합니다.
 다음과 같은 과정을 통해 실행 환경을 구축할 수 있습니다.
 - 가상환경 구축 (Conda 또는 Venv)
 - git clone 명령어로 HRET GitHub 프로젝트를 로컬에 복사해오기
 - 요구 패키지 설치
 
-## Conda 가상환경 (Virtual Environment) 구현 예시 
-[1] 아나콘다 설치 https://www.anaconda.com/download   
+## Conda 가상환경 (Virtual Environment) 구현 예시
+[1] 아나콘다 설치 https://www.anaconda.com/download
    (다운로드 페이지 우측 하단의 skip registration으로 가입없이 설치 가능)
 
 [2] Anaconda prompt 실행
@@ -119,10 +119,40 @@ df = results.to_dataframe()
 print(df) # input, reference, prediction, options, chain-of-thought, logits, 등 확인 가능
 ```
 
+### 설정 파일 사용
+
+여러 매개변수를 코드로 전달하는 대신 하나의 YAML 파일로 전체 파이프라인을 제어할 수 있습니다.
+`evaluator_config.yaml`을 생성해 보세요:
+
+```yaml
+dataset:
+  name: haerae_bench
+  split: test
+  params: {}
+model:
+  name: huggingface
+  params:
+    model_name_or_path: gpt2
+evaluation:
+  method: string_match
+  params: {}
+language_penalize: false
+```
+
+사용 예:
+
+```python
+from llm_eval.evaluator import run_from_config
+
+result = run_from_config("evaluator_config.yaml")
+```
+
+모든 필드는 `examples/evaluator_config.yaml` 템플릿을 참고하세요.
+
 ## 👌Output 평가
 
 ### Raw 데이터 직접 분석하기: to_dataframe()
-가장 기본적이면서 강력한 분석 방법은 평가 결과 전체를 pandas.DataFrame으로 변환하여 직접 다루는 것입니다. 
+가장 기본적이면서 강력한 분석 방법은 평가 결과 전체를 pandas.DataFrame으로 변환하여 직접 다루는 것입니다.
 results.to_dataframe() 메서드를 사용하면 평가 과정의 모든 샘플 데이터를 로우 포맷으로 받아와 자유롭게 분석할 수 있습니다. 미리 정의된 리포트 외에 자신만의 기준으로 데이터를 심층 분석하고 싶을 때 매우 유용합니다.
 
 ```python
@@ -157,7 +187,7 @@ _subset_name: 해당 샘플이 속한 서브셋 이름
 이를 활용하여 특정 조건의 샘플만 필터링하거나, 그룹별로 통계를 내는 등 pandas 라이브러리의 모든 기능을 활용하여 무한한 가능성의 커스텀 분석을 수행할 수 있습니다.
 
 ### 자동 분석 리포트 활용하기: analysis_report()
-매번 직접 데이터를 분석하는 것이 번거로울 수 있습니다. 이를 위해 툴킷은 한국어의 특성에 맞는 주요 분석 항목들을 종합하여 보여주는 자동화된 리포팅 기능을 제공합니다. analysis_report() 메서드는 클릭 한 번으로 종합적인 분석 리포트를 생성합니다. 
+매번 직접 데이터를 분석하는 것이 번거로울 수 있습니다. 이를 위해 툴킷은 한국어의 특성에 맞는 주요 분석 항목들을 종합하여 보여주는 자동화된 리포팅 기능을 제공합니다. analysis_report() 메서드는 클릭 한 번으로 종합적인 분석 리포트를 생성합니다.
 
 ####  분석 리포트 생성 및 출력
 ```python
@@ -378,7 +408,7 @@ cot_parser는 pythonpath안에 함수가 위치한 곳 이름만 적어두면, �
 
 ## FAQ
 Q. 다음 에러 메시지가 출력됩니다: 'Make sure to have access to it at {model url} 403 Client Error. (Request ID: ~~ )'
-A. 해당 모델(ex: Llama, Gemma, etc)은 허깅페이스 로그인 후 모델 페이지 상단에 있는 
+A. 해당 모델(ex: Llama, Gemma, etc)은 허깅페이스 로그인 후 모델 페이지 상단에 있는
 {Model Name} COMMUNITY LICENSE AGREEMENT의 하단에 Expand to review and access 클릭 후 정보 입력한 다음 Submit 후 허가를 받은 다음 (약 10분) 사용하실 수 있습니다.
 
 ---

--- a/examples/evaluator_config.yaml
+++ b/examples/evaluator_config.yaml
@@ -1,0 +1,59 @@
+# Evaluator Configuration File
+# This file defines every component required to reproduce an evaluation
+# pipeline using the Evaluator API.
+
+# Dataset settings
+# - name: dataset registry key
+# - subset: optional subset or list of subsets
+# - split: data split to evaluate on
+# - params: additional dataset-specific kwargs
+
+dataset:
+  name: "haerae_bench"
+  subset: null
+  split: "test"
+  params: {}
+
+# Generation model settings
+# - name: model backend registry key
+# - params: backend-specific options
+model:
+  name: "huggingface"
+  params:
+    model_name_or_path: "gpt2"
+
+# Judge model settings (optional)
+judge_model:
+  name: null
+  params: {}
+
+# Reward model settings (optional)
+reward_model:
+  name: null
+  params: {}
+
+# Test-time scaling method (optional)
+scaling:
+  name: null
+  params: {}
+
+# Evaluation method and its parameters
+# e.g., string_match, log_prob, llm_judge
+
+evaluation:
+  method: "string_match"
+  params: {}
+
+# Global evaluator options
+language_penalize: true
+target_lang: "ko"
+custom_cot_parser: null
+
+# Few-shot prompting configuration
+few_shot:
+  num: 0
+  split: null
+  instruction: "Use the following examples to answer the question."
+  example_template: |
+    Q: {input}
+    A: {reference}

--- a/llm_eval/test/test_evaluator_config.py
+++ b/llm_eval/test/test_evaluator_config.py
@@ -1,0 +1,37 @@
+import yaml
+
+from llm_eval.datasets import BaseDataset, register_dataset
+from llm_eval.evaluator import run_from_config
+from llm_eval.models import BaseModel, register_model
+
+
+@register_dataset("dummy_dataset")
+class DummyDataset(BaseDataset):
+    def __init__(self, split: str = "test", **kwargs):
+        super().__init__(dataset_name="dummy_dataset", split=split)
+
+    def load(self):
+        return [{"input": "hello", "reference": "hello"}]
+
+
+@register_model("dummy_model")
+class DummyModel(BaseModel):
+    def generate_batch(self, inputs, return_logits=False, **kwargs):
+        for sample in inputs:
+            sample["prediction"] = sample["input"]
+        return inputs
+
+
+def test_run_from_config(tmp_path):
+    cfg = {
+        "dataset": {"name": "dummy_dataset", "split": "test", "params": {}},
+        "model": {"name": "dummy_model", "params": {}},
+        "evaluation": {"method": "string_match", "params": {}},
+        "language_penalize": False,
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump(cfg))
+
+    result = run_from_config(str(config_file))
+    assert result.metrics["accuracy"] == 1.0
+    assert len(result.samples) == 1


### PR DESCRIPTION
## Summary
- add `run_from_config` to Evaluator for executing pipelines via YAML/JSON files
- provide `examples/evaluator_config.yaml` template covering dataset, model, judge, reward, scaling, evaluation, and few-shot options
- document configuration-based usage in README and quick-start guides
- add unit test verifying pipeline execution from a YAML config

## Testing
- `pre-commit run --files README.md docs/eng/01-quick-start.md docs/kor/01-quick-start.md llm_eval/evaluator.py examples/evaluator_config.yaml llm_eval/test/test_evaluator_config.py` *(failed: flake8, mypy reports many existing errors)*
- `SKIP=flake8,mypy,autopep8 pre-commit run --files README.md docs/eng/01-quick-start.md docs/kor/01-quick-start.md llm_eval/evaluator.py examples/evaluator_config.yaml llm_eval/test/test_evaluator_config.py`
- `pytest llm_eval/test/test_evaluator_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68916366d1f48320b1a51f3e5824d200