### PR TITLE
Add PyPI installation instructions to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ We are actively developing core features and interfaces. Current goals include:
 
 ## ⚙️ Installation
 
+### Option 1: Install from PyPI (Recommended)
+
+```bash
+pip install haerae-evaluation-toolkit
+```
+
+### Option 2: Install from Source
+
 1.  **Clone the repository:**
     ```bash
     git clone https://github.com/HAE-RAE/haerae-evaluation-toolkit.git

--- a/docs/eng/01-quick-start.md
+++ b/docs/eng/01-quick-start.md
@@ -16,13 +16,25 @@ The HRET framework addresses inconsistencies in existing Korean LLM evaluation m
 
 # Installation
 
+## Option 1: Install from PyPI (Recommended)
+
+The easiest way to install HRET is via PyPI:
+
+```bash
+pip install haerae-evaluation-toolkit
+```
+
+## Option 2: Install from Source
+
+If you want to install from source or contribute to the project, follow these steps:
+
 It is recommended to create and activate a Python (≥3.10) virtual environment before installing. The following steps outline the setup process:
 
 1. Create and activate a virtual environment (Conda or venv)
 2. Clone the HRET GitHub repository
 3. Install required packages
 
-## Example: Conda Environment
+### Example: Conda Environment
 
 1. Download and install Anaconda: [https://www.anaconda.com/download](https://www.anaconda.com/download) (click “skip registration” to install without signing up)
 2. Open the Anaconda Prompt

--- a/docs/kor/01-quick-start.md
+++ b/docs/kor/01-quick-start.md
@@ -14,13 +14,26 @@ HRET 프레임워크는 기존 한국어 LLM 평가 방식이 일관되지 않�
 ---
 
 # 설치 (Installation)
+
+## 방법 1: PyPI에서 설치 (권장)
+
+가장 간단한 설치 방법은 PyPI를 통한 설치입니다:
+
+```bash
+pip install haerae-evaluation-toolkit
+```
+
+## 방법 2: 소스에서 설치
+
+소스에서 설치하거나 프로젝트에 기여하고 싶다면 다음 단계를 따르세요:
+
 파이썬(python >= 3.10) 가상환경 구축 후 설치를 권장합니다.
 다음과 같은 과정을 통해 실행 환경을 구축할 수 있습니다.
 - 가상환경 구축 (Conda 또는 Venv)
 - git clone 명령어로 HRET GitHub 프로젝트를 로컬에 복사해오기
 - 요구 패키지 설치
 
-## Conda 가상환경 (Virtual Environment) 구현 예시
+### Conda 가상환경 (Virtual Environment) 구현 예시
 [1] 아나콘다 설치 https://www.anaconda.com/download
    (다운로드 페이지 우측 하단의 skip registration으로 가입없이 설치 가능)
 


### PR DESCRIPTION
## 📦 Add PyPI Installation Instructions

This PR updates the documentation to include PyPI installation instructions now that the package has been successfully published to PyPI.

### Changes Made

- **README.md**: Added PyPI installation as the recommended method (Option 1) while keeping source installation as an alternative (Option 2)
- **docs/eng/01-quick-start.md**: Updated English documentation with PyPI installation instructions
- **docs/kor/01-quick-start.md**: Updated Korean documentation with PyPI installation instructions

### Installation Command

Users can now install the package easily with:
```bash
pip install haerae-evaluation-toolkit
```

### Package Information

- **PyPI Package**: https://pypi.org/project/haerae-evaluation-toolkit/0.1.0/
- **Version**: 0.1.0
- **Successfully published**: ✅

### Documentation Structure

The installation sections now follow this structure:
1. **Option 1/방법 1**: PyPI installation (recommended)
2. **Option 2/방법 2**: Source installation (for contributors)

This makes it easier for users to get started while still providing the source installation option for developers who want to contribute to the project.

### Testing

- [x] Package builds successfully
- [x] Package passes `twine check`
- [x] Package uploaded to PyPI successfully
- [x] Documentation updated in both English and Korean

@h-albert-lee can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f44347ec822743ddaee634cdbd84c8c9)