### PR TITLE
fix: Fix async ordering bug and add BenchHub dataset support

### DIFF
--- a/llm_eval/datasets/benchhub.py
+++ b/llm_eval/datasets/benchhub.py
@@ -99,6 +99,10 @@ class BenchHubDataset(BaseDataset):
         hf_load_kwargs: Optional[Dict[str, Any]] = None, # HuggingFace load_dataset에 전달할 추가 인자
         **kwargs 
     ):
+        # Remove duplicate arguments from kwargs to prevent conflicts
+        kwargs.pop('subset', None)
+        kwargs.pop('split', None)
+        
         super().__init__(
             dataset_name=dataset_name,
             split=split,


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in async batch generation that caused prompt-response mismatches, and adds comprehensive BenchHub dataset support with multiple bug fixes.

## Changes

### 1. Critical Bug Fix (`llm_eval/models/openai_backend.py`)
**Commit**: `fix: Prevent prompt-response mismatch in async batch generation`

- **Fix prompt-response ordering**: Replace `asyncio.as_completed` with `asyncio.gather` to maintain input order
- **Add rate limiting**: Use `asyncio.Semaphore` to prevent API rate limit errors
- **Result**: Fixes 0% accuracy issue caused by mismatched prompts and responses

### 2. BenchHub Dataset Improvements (`llm_eval/datasets/benchhub.py`)
**Commit**: `feat: Improve BenchHub dataset loader`

- **Add sampling**: `sample_size` and `seed` parameters for reproducible evaluations
- **MCQA templates**: Generate `options_str` for multiple-choice questions
- **Answer priority**: Prioritize `answer_str` → `answer` → `reference`
- **Remove deprecated**: Remove `trust_remote_code` parameter

### 3. Bug Fix (`llm_eval/datasets/benchhub.py`)
**Commit**: `fix: Remove duplicate subset/split from kwargs to prevent conflicts`

- **Fix duplicate kwargs**: Remove `subset` and `split` from kwargs to prevent `TypeError`
- **Prevents**: `__init__() got multiple values for keyword argument 'subset'` error

## Testing

Tested with:
- ✅ gpt-3.5-turbo: 35% accuracy (was 0% before fix)
- ✅ 100 samples correctly processed (was 137,529 before sample_size fix)
- ✅ Sample size limit: Set to 100 samples for development/testing purposes
- ✅ Prompt-response pairs correctly matched
- ✅ No duplicate kwargs errors